### PR TITLE
[CUS-9] 문제 목록 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/continuous/backend/domain/CourseRepository.java
+++ b/src/main/java/com/continuous/backend/domain/CourseRepository.java
@@ -1,0 +1,6 @@
+package com.continuous.backend.domain;
+
+public interface CourseRepository {
+
+    Course findByProblemId(long problemId);
+}

--- a/src/main/java/com/continuous/backend/domain/Problem.java
+++ b/src/main/java/com/continuous/backend/domain/Problem.java
@@ -1,21 +1,15 @@
 package com.continuous.backend.domain;
 
-import java.util.List;
-
 public class Problem {
 
     private final long id;
     private final String title;
-    private final List<Tag> tags;
-    private final Course course;
 
-    public Problem(long id, String title, List<Tag> tags, Course course) {
+    public Problem(long id, String title) {
         validateTitle(title);
 
         this.id = id;
         this.title = title;
-        this.tags = tags;
-        this.course = course;
     }
 
     private void validateTitle(String title) {

--- a/src/main/java/com/continuous/backend/domain/Problem.java
+++ b/src/main/java/com/continuous/backend/domain/Problem.java
@@ -1,5 +1,8 @@
 package com.continuous.backend.domain;
 
+import lombok.Getter;
+
+@Getter
 public class Problem {
 
     private final long id;

--- a/src/main/java/com/continuous/backend/domain/ProblemRepository.java
+++ b/src/main/java/com/continuous/backend/domain/ProblemRepository.java
@@ -1,0 +1,8 @@
+package com.continuous.backend.domain;
+
+import java.util.List;
+
+public interface ProblemRepository {
+
+    List<Problem> findAll();
+}

--- a/src/main/java/com/continuous/backend/domain/ProblemService.java
+++ b/src/main/java/com/continuous/backend/domain/ProblemService.java
@@ -1,0 +1,19 @@
+package com.continuous.backend.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProblemService {
+
+    private final ProblemRepository problemRepository;
+
+    public ProblemService(ProblemRepository problemRepository) {
+        this.problemRepository = problemRepository;
+    }
+
+    public List<Problem> getProblems() {
+        return problemRepository.findAll();
+    }
+}

--- a/src/main/java/com/continuous/backend/domain/ProblemService.java
+++ b/src/main/java/com/continuous/backend/domain/ProblemService.java
@@ -1,5 +1,6 @@
 package com.continuous.backend.domain;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -28,5 +29,27 @@ public class ProblemService {
                 List<Tag> tags = tagRepository.findAllByProblemId(problem.getId());
                 return new ProblemWithMetadata(problem, course, tags);
             }).toList();
+    }
+
+    public List<ProblemWithMetadata> getProblemsWithMetadataFiltered(String course, List<String> tags) {
+        List<ProblemWithMetadata> problems = getProblemsWithMetadata();
+
+        List<Tag> filteringTags;
+        if (tags != null) {
+            filteringTags = tags.stream().map(Tag::from).toList();
+        } else {
+            filteringTags = new ArrayList<>();
+        }
+
+        return problems.stream()
+            .filter(problem -> {
+                boolean courseMatches = (course == null) || problem.getCourse().equals(Course.from(course));
+
+                boolean tagsMatch = filteringTags.isEmpty() ||
+                    problem.getTags().stream().anyMatch(filteringTags::contains);
+
+                return courseMatches && tagsMatch;
+            })
+            .toList();
     }
 }

--- a/src/main/java/com/continuous/backend/domain/ProblemService.java
+++ b/src/main/java/com/continuous/backend/domain/ProblemService.java
@@ -8,12 +8,25 @@ import org.springframework.stereotype.Service;
 public class ProblemService {
 
     private final ProblemRepository problemRepository;
+    private final CourseRepository courseRepository;
+    private final TagRepository tagRepository;
 
-    public ProblemService(ProblemRepository problemRepository) {
+    public ProblemService(ProblemRepository problemRepository, CourseRepository courseRepository, TagRepository tagRepository) {
         this.problemRepository = problemRepository;
+        this.tagRepository = tagRepository;
+        this.courseRepository = courseRepository;
     }
 
     public List<Problem> getProblems() {
         return problemRepository.findAll();
+    }
+
+    public List<ProblemWithMetadata> getProblemsWithMetadata() {
+        return getProblems().stream()
+            .map(problem -> {
+                Course course = courseRepository.findByProblemId(problem.getId());
+                List<Tag> tags = tagRepository.findAllByProblemId(problem.getId());
+                return new ProblemWithMetadata(problem, course, tags);
+            }).toList();
     }
 }

--- a/src/main/java/com/continuous/backend/domain/ProblemWithMetadata.java
+++ b/src/main/java/com/continuous/backend/domain/ProblemWithMetadata.java
@@ -1,0 +1,19 @@
+package com.continuous.backend.domain;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class ProblemWithMetadata {
+
+    private final Problem problem;
+    private final Course course;
+    private final List<Tag> tags;
+
+    public ProblemWithMetadata(Problem problem, Course course, List<Tag> tags) {
+        this.problem = problem;
+        this.course = course;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/continuous/backend/domain/TagRepository.java
+++ b/src/main/java/com/continuous/backend/domain/TagRepository.java
@@ -1,0 +1,8 @@
+package com.continuous.backend.domain;
+
+import java.util.List;
+
+public interface TagRepository {
+
+    List<Tag> findAllByProblemId(long problemId);
+}

--- a/src/main/java/com/continuous/backend/infrastructure/CourseCoreRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/CourseCoreRepository.java
@@ -1,0 +1,25 @@
+package com.continuous.backend.infrastructure;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Repository;
+
+import com.continuous.backend.domain.Course;
+import com.continuous.backend.domain.CourseRepository;
+
+@Repository
+public class CourseCoreRepository implements CourseRepository {
+
+    private final CourseJpaRepository CourseJpaRepository;
+
+    public CourseCoreRepository(CourseJpaRepository CourseJpaRepository) {
+        this.CourseJpaRepository = CourseJpaRepository;
+    }
+
+    @Override
+    public Course findByProblemId(long problemId) {
+        CourseEntity courseEntity = CourseJpaRepository.findByProblemId(problemId)
+            .orElseThrow(() -> new NoSuchElementException("해당 problemId 에 해당하는 코스가 존재하지 않습니다. problemId: " + problemId));
+        return courseEntity.toCourse();
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/CourseEntity.java
+++ b/src/main/java/com/continuous/backend/infrastructure/CourseEntity.java
@@ -1,0 +1,31 @@
+package com.continuous.backend.infrastructure;
+
+import com.continuous.backend.domain.Course;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "course")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    public Course toCourse() {
+        return Course.from(name);
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/CourseJpaRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/CourseJpaRepository.java
@@ -1,0 +1,13 @@
+package com.continuous.backend.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CourseJpaRepository extends JpaRepository<CourseEntity, Long> {
+
+    @Query(value = "SELECT c.id AS id, c.name AS name FROM course c JOIN problem_course pc ON c.id = pc.course_id WHERE pc.problem_id = :problemId", nativeQuery = true)
+    Optional<CourseEntity> findByProblemId(@Param("problemId") long problemId);
+}

--- a/src/main/java/com/continuous/backend/infrastructure/ProblemCoreRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/ProblemCoreRepository.java
@@ -1,0 +1,25 @@
+package com.continuous.backend.infrastructure;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.continuous.backend.domain.Problem;
+import com.continuous.backend.domain.ProblemRepository;
+
+@Repository
+public class ProblemCoreRepository implements ProblemRepository {
+
+    private final ProblemJpaRepository problemJpaRepository;
+
+    public ProblemCoreRepository(ProblemJpaRepository problemJpaRepository) {
+        this.problemJpaRepository = problemJpaRepository;
+    }
+
+    @Override
+    public List<Problem> findAll() {
+        return problemJpaRepository.findAll().stream()
+            .map(ProblemEntity::toProblem)
+            .toList();
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/ProblemCourseEntity.java
+++ b/src/main/java/com/continuous/backend/infrastructure/ProblemCourseEntity.java
@@ -1,0 +1,28 @@
+package com.continuous.backend.infrastructure;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "problem_course")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemCourseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id")
+    private long problemId;
+
+    @Column(name = "course_id")
+    private long courseId;
+}

--- a/src/main/java/com/continuous/backend/infrastructure/ProblemEntity.java
+++ b/src/main/java/com/continuous/backend/infrastructure/ProblemEntity.java
@@ -1,0 +1,31 @@
+package com.continuous.backend.infrastructure;
+
+import com.continuous.backend.domain.Problem;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "problem")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    public Problem toProblem() {
+        return new Problem(id, title);
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/ProblemJpaRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/ProblemJpaRepository.java
@@ -1,0 +1,6 @@
+package com.continuous.backend.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemJpaRepository extends JpaRepository<ProblemEntity, Long> {
+}

--- a/src/main/java/com/continuous/backend/infrastructure/ProblemTagEntity.java
+++ b/src/main/java/com/continuous/backend/infrastructure/ProblemTagEntity.java
@@ -1,0 +1,28 @@
+package com.continuous.backend.infrastructure;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "problem_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemTagEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id")
+    private long problemId;
+
+    @Column(name = "tag_id")
+    private long tagId;
+}

--- a/src/main/java/com/continuous/backend/infrastructure/TagCoreRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/TagCoreRepository.java
@@ -1,0 +1,25 @@
+package com.continuous.backend.infrastructure;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.continuous.backend.domain.Tag;
+import com.continuous.backend.domain.TagRepository;
+
+@Repository
+public class TagCoreRepository implements TagRepository {
+
+    private final TagJpaRepository tagJpaRepository;
+
+    public TagCoreRepository(TagJpaRepository tagJpaRepository) {
+        this.tagJpaRepository = tagJpaRepository;
+    }
+
+    @Override
+    public List<Tag> findAllByProblemId(long problemId) {
+        return tagJpaRepository.findAllByProblemId(problemId).stream()
+            .map(TagEntity::toTag)
+            .toList();
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/TagEntity.java
+++ b/src/main/java/com/continuous/backend/infrastructure/TagEntity.java
@@ -1,0 +1,31 @@
+package com.continuous.backend.infrastructure;
+
+import com.continuous.backend.domain.Tag;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    public Tag toTag() {
+        return Tag.from(name);
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/TagJpaRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/TagJpaRepository.java
@@ -1,0 +1,13 @@
+package com.continuous.backend.infrastructure;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TagJpaRepository extends JpaRepository<TagEntity, Long> {
+
+    @Query(value = "SELECT t.id, t.name FROM tag as t JOIN problem_tag as pt on t.id = pt.tag_id WHERE pt.problem_id = :problemId", nativeQuery = true)
+    List<TagEntity> findAllByProblemId(@Param("problemId") long problemId);
+}

--- a/src/main/java/com/continuous/backend/presentation/ProblemController.java
+++ b/src/main/java/com/continuous/backend/presentation/ProblemController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.continuous.backend.domain.ProblemService;
@@ -22,8 +23,11 @@ public class ProblemController {
     }
 
     @GetMapping
-    public ApiResponse<List<ProblemResponse>> getProblems() {
-        List<ProblemWithMetadata> problemsWithMetadata = problemService.getProblemsWithMetadata();
+    public ApiResponse<List<ProblemResponse>> getProblems(
+        @RequestParam(required = false) String course,
+        @RequestParam(required = false) List<String> tags
+    ) {
+        List<ProblemWithMetadata> problemsWithMetadata = problemService.getProblemsWithMetadataFiltered(course, tags);
         List<ProblemResponse> responses = problemsWithMetadata.stream()
             .map(ProblemResponse::from)
             .toList();

--- a/src/main/java/com/continuous/backend/presentation/ProblemController.java
+++ b/src/main/java/com/continuous/backend/presentation/ProblemController.java
@@ -1,0 +1,33 @@
+package com.continuous.backend.presentation;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.continuous.backend.domain.ProblemService;
+import com.continuous.backend.domain.ProblemWithMetadata;
+import com.continuous.backend.presentation.response.ProblemResponse;
+import com.continuous.backend.support.ApiResponse;
+
+@RestController
+@RequestMapping("/v1/problems")
+public class ProblemController {
+
+    private final ProblemService problemService;
+
+    public ProblemController(ProblemService problemService) {
+        this.problemService = problemService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<ProblemResponse>> getProblems() {
+        List<ProblemWithMetadata> problemsWithMetadata = problemService.getProblemsWithMetadata();
+        List<ProblemResponse> responses = problemsWithMetadata.stream()
+            .map(ProblemResponse::from)
+            .toList();
+
+        return ApiResponse.success(responses);
+    }
+}

--- a/src/main/java/com/continuous/backend/presentation/response/ProblemResponse.java
+++ b/src/main/java/com/continuous/backend/presentation/response/ProblemResponse.java
@@ -1,0 +1,17 @@
+package com.continuous.backend.presentation.response;
+
+import java.util.List;
+
+import com.continuous.backend.domain.Problem;
+import com.continuous.backend.domain.ProblemWithMetadata;
+
+public record ProblemResponse(long id, String title, String course, List<String> tags) {
+    public static ProblemResponse from(ProblemWithMetadata problemWithMetadata) {
+        Problem problem = problemWithMetadata.getProblem();
+        List<String> tags = problemWithMetadata.getTags().stream()
+            .map(Enum::name)
+            .toList();
+
+        return new ProblemResponse(problem.getId(), problem.getTitle(), problemWithMetadata.getCourse().name(), tags);
+    }
+}

--- a/src/main/java/com/continuous/backend/support/ApiResponse.java
+++ b/src/main/java/com/continuous/backend/support/ApiResponse.java
@@ -1,0 +1,12 @@
+package com.continuous.backend.support;
+
+public record ApiResponse<T>(String status, String message, T data) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", null, data);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>("error", message, null);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=continuous-backend
+spring.jpa.show-sql=true

--- a/src/test/java/com/continuous/backend/domain/ProblemServiceTest.java
+++ b/src/test/java/com/continuous/backend/domain/ProblemServiceTest.java
@@ -1,0 +1,32 @@
+package com.continuous.backend.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.continuous.backend.support.MockProblemRepository;
+
+class ProblemServiceTest {
+
+    private ProblemService problemService;
+
+    @BeforeEach
+    void setUp() {
+        MockProblemRepository problemRepository = new MockProblemRepository();
+        problemService = new ProblemService(problemRepository);
+    }
+
+    @DisplayName("문제 목록을 가져온다.")
+    @Test
+    void getProblems() {
+        // when
+        List<Problem> problems = problemService.getProblems();
+
+        // then
+        assertThat(problems).hasSize(2);
+    }
+}

--- a/src/test/java/com/continuous/backend/domain/ProblemServiceTest.java
+++ b/src/test/java/com/continuous/backend/domain/ProblemServiceTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.continuous.backend.support.MockCourseRepository;
 import com.continuous.backend.support.MockProblemRepository;
+import com.continuous.backend.support.MockTagRepository;
 
 class ProblemServiceTest {
 
@@ -17,7 +19,9 @@ class ProblemServiceTest {
     @BeforeEach
     void setUp() {
         MockProblemRepository problemRepository = new MockProblemRepository();
-        problemService = new ProblemService(problemRepository);
+        MockCourseRepository courseRepository = new MockCourseRepository();
+        MockTagRepository tagRepository = new MockTagRepository();
+        problemService = new ProblemService(problemRepository, courseRepository, tagRepository);
     }
 
     @DisplayName("문제 목록을 가져온다.")
@@ -28,5 +32,19 @@ class ProblemServiceTest {
 
         // then
         assertThat(problems).hasSize(2);
+    }
+
+    @DisplayName("문제 메타데이터 목록을 가져온다.")
+    @Test
+    void getProblemWithMetadata() {
+        // when
+        List<ProblemWithMetadata> problems = problemService.getProblemsWithMetadata();
+
+        //then
+        assertThat(problems).hasSize(2);
+        assertThat(problems.get(0).getCourse()).isEqualTo(Course.BACKEND);
+        assertThat(problems.get(0).getTags()).containsExactly(Tag.JAVA);
+        assertThat(problems.get(1).getCourse()).isEqualTo(Course.FRONTEND);
+        assertThat(problems.get(1).getTags()).containsExactly(Tag.JAVASCRIPT);
     }
 }

--- a/src/test/java/com/continuous/backend/domain/ProblemTest.java
+++ b/src/test/java/com/continuous/backend/domain/ProblemTest.java
@@ -2,8 +2,6 @@ package com.continuous.backend.domain;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,7 +14,7 @@ class ProblemTest {
     @ValueSource(strings = {"", "  "})
     void create_emptyTitle(String title) {
         // when & then
-        assertThatThrownBy(() -> new Problem(1L, title, List.of(Tag.JAVA), Course.BACKEND))
+        assertThatThrownBy(() -> new Problem(1L, title))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("문제의 제목은 비어있거나 50자를 넘을 수 없습니다.");
     }
@@ -28,7 +26,7 @@ class ProblemTest {
         String title = "오십한글자문제의제목오십한글자문제의제목오십한글자문제의제목오십한글자문제의제목오십한글자문제의제목오";
 
         // when & then
-        assertThatThrownBy(() -> new Problem(1L, title, List.of(Tag.JAVA), Course.BACKEND))
+        assertThatThrownBy(() -> new Problem(1L, title))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("문제의 제목은 비어있거나 50자를 넘을 수 없습니다.");
     }

--- a/src/test/java/com/continuous/backend/infrastructure/CourseCoreRepositoryTest.java
+++ b/src/test/java/com/continuous/backend/infrastructure/CourseCoreRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.continuous.backend.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.continuous.backend.domain.Course;
+import com.continuous.backend.domain.CourseRepository;
+
+@DataJpaTest
+@Import(CourseCoreRepository.class)
+class CourseCoreRepositoryTest {
+
+    @Autowired
+    private CourseRepository courseCoreRepository;
+
+    @DisplayName("문제 ID에 해당하는 코스를 조회한다.")
+    @Test
+    @Sql(scripts = "/course-test-data.sql")
+    void findByProblemId() {
+        // given
+        long problemId = 1L;
+
+        // when
+        Course course = courseCoreRepository.findByProblemId(problemId);
+
+        //then
+        assertThat(course).isNotNull();
+        assertThat(course).isEqualTo(Course.BACKEND);
+    }
+}

--- a/src/test/java/com/continuous/backend/infrastructure/TagCoreRepositoryTest.java
+++ b/src/test/java/com/continuous/backend/infrastructure/TagCoreRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.continuous.backend.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.continuous.backend.domain.Tag;
+import com.continuous.backend.domain.TagRepository;
+
+@DataJpaTest
+@Import(TagCoreRepository.class)
+public class TagCoreRepositoryTest {
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @DisplayName("Problem ID로 태그를 조회한다")
+    @Sql(scripts = "/tag-test-data.sql")
+    @Test
+    void findAllByProblemId() {
+        // Given
+        long problemId = 1L;
+
+        // When
+        List<Tag> tags = tagRepository.findAllByProblemId(problemId);
+
+        // Then
+        assertThat(tags).isNotEmpty();
+        assertThat(tags).hasSize(2);
+        assertThat(tags).containsExactly(Tag.JAVA, Tag.JAVASCRIPT);
+    }
+}

--- a/src/test/java/com/continuous/backend/presentation/ProblemControllerIntegrationTest.java
+++ b/src/test/java/com/continuous/backend/presentation/ProblemControllerIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.continuous.backend.presentation;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "/integration-test-data.sql")
+class ProblemControllerIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("GET /problems - 문제 목록을 가져온다.")
+    @Test
+    void getProblems() {
+        given()
+            .contentType(ContentType.JSON)
+            .when()
+            .get("/v1/problems")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("status", equalTo("success"))
+            .body("data", not(empty()))
+            .body("data.size()", greaterThan(0))
+            .body("data[0].title", notNullValue())
+            .body("data[0].course", notNullValue())
+            .body("data[0].tags", not(empty()));
+    }
+}

--- a/src/test/java/com/continuous/backend/presentation/ProblemControllerIntegrationTest.java
+++ b/src/test/java/com/continuous/backend/presentation/ProblemControllerIntegrationTest.java
@@ -3,26 +3,40 @@ package com.continuous.backend.presentation;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Sql(scripts = "/integration-test-data.sql")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ProblemControllerIntegrationTest {
 
     @LocalServerPort
     private int port;
 
-    @BeforeEach
-    public void setUp() {
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeAll
+    public void setUp() throws IOException {
         RestAssured.port = port;
+
+        executeSqlScript("integration-test-data.sql");
+    }
+
+    private void executeSqlScript(String scriptPath) throws IOException {
+        String sql = new String(getClass().getClassLoader().getResourceAsStream(scriptPath).readAllBytes());
+        jdbcTemplate.execute(sql);
     }
 
     @DisplayName("GET /problems - 문제 목록을 가져온다.")
@@ -41,5 +55,74 @@ class ProblemControllerIntegrationTest {
             .body("data[0].title", notNullValue())
             .body("data[0].course", notNullValue())
             .body("data[0].tags", not(empty()));
+    }
+
+    @DisplayName("GET /problems - 특정 코스로 필터링한다.")
+    @Test
+    void getProblemsFilteredByCourse() {
+        given()
+            .contentType(ContentType.JSON)
+            .queryParam("course", "FRONTEND")
+            .when()
+            .get("/v1/problems")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("status", equalTo("success"))
+            .body("data", not(empty()))
+            .body("data.size()", greaterThan(0))
+            .body("data.findAll { it.course == 'FRONTEND' }", not(empty()));
+    }
+
+    @DisplayName("GET /problems - 특정 태그로 필터링한다.")
+    @Test
+    void getProblemsFilteredBySingleTag() {
+        given()
+            .contentType(ContentType.JSON)
+            .queryParam("tags", "JAVASCRIPT")
+            .when()
+            .get("/v1/problems")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("status", equalTo("success"))
+            .body("data", not(empty()))
+            .body("data.size()", greaterThan(0))
+            .body("data.tags.flatten()", hasItem("JAVASCRIPT"));
+    }
+
+    @DisplayName("GET /problems - 여러 태그로 필터링한다.")
+    @Test
+    void getProblemsFilteredByMultipleTags() {
+        given()
+            .contentType(ContentType.JSON)
+            .queryParam("tags", "JAVASCRIPT,JAVA")
+            .when()
+            .get("/v1/problems")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("status", equalTo("success"))
+            .body("data", not(empty()))
+            .body("data.size()", greaterThan(0))
+            .body("data.tags.flatten()", anyOf(hasItem("JAVASCRIPT"), hasItem("JAVA")));
+    }
+
+    @DisplayName("GET /problems - 코스와 태그로 필터링한다.")
+    @Test
+    void getProblemsFilteredByCourseAndTags() {
+        given()
+            .contentType(ContentType.JSON)
+            .queryParam("course", "FRONTEND")
+            .queryParam("tags", "JAVASCRIPT,JAVA")
+            .when()
+            .get("/v1/problems")
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("status", equalTo("success"))
+            .body("data", not(empty()))
+            .body("data.findAll { it.course == 'FRONTEND' }", not(empty()))
+            .body("data.tags.flatten()", anyOf(hasItem("JAVASCRIPT"), hasItem("JAVA")));
     }
 }

--- a/src/test/java/com/continuous/backend/support/MockCourseRepository.java
+++ b/src/test/java/com/continuous/backend/support/MockCourseRepository.java
@@ -1,0 +1,18 @@
+package com.continuous.backend.support;
+
+import com.continuous.backend.domain.Course;
+import com.continuous.backend.domain.CourseRepository;
+
+public class MockCourseRepository implements CourseRepository {
+
+    @Override
+    public Course findByProblemId(long problemId) {
+        if (problemId == 1) {
+            return Course.BACKEND;
+        } else if (problemId == 2) {
+            return Course.FRONTEND;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/continuous/backend/support/MockProblemRepository.java
+++ b/src/test/java/com/continuous/backend/support/MockProblemRepository.java
@@ -1,0 +1,24 @@
+package com.continuous.backend.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.continuous.backend.domain.Problem;
+import com.continuous.backend.domain.ProblemRepository;
+
+public class MockProblemRepository implements ProblemRepository {
+
+    @Override
+    public List<Problem> findAll() {
+        // 샘플 데이터 생성
+        Problem problem1 = new Problem(1L, "자바 Enum에 대해서 설명해주세요.");
+        Problem problem2 = new Problem(2L, "클로저에 대해서 설명해주세요.");
+
+        // 반환할 리스트
+        List<Problem> problems = new ArrayList<>();
+        problems.add(problem1);
+        problems.add(problem2);
+
+        return problems;
+    }
+}

--- a/src/test/java/com/continuous/backend/support/MockTagRepository.java
+++ b/src/test/java/com/continuous/backend/support/MockTagRepository.java
@@ -1,0 +1,22 @@
+package com.continuous.backend.support;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.continuous.backend.domain.Tag;
+import com.continuous.backend.domain.TagRepository;
+
+public class MockTagRepository implements TagRepository {
+
+    @Override
+    public List<Tag> findAllByProblemId(long problemId) {
+        if (problemId == 1) {
+            return Arrays.asList(Tag.JAVA);
+        } else if (problemId == 2) {
+            return Arrays.asList(Tag.JAVASCRIPT);
+        } else {
+            return new ArrayList<>(); // 빈 리스트 반환
+        }
+    }
+}

--- a/src/test/resources/course-test-data.sql
+++ b/src/test/resources/course-test-data.sql
@@ -1,0 +1,11 @@
+-- Create and insert data for course table
+INSERT INTO course (id, name)
+VALUES (1, 'BACKEND');
+INSERT INTO course (id, name)
+VALUES (2, 'FRONTEND');
+
+-- Create and insert data for problem_course table
+INSERT INTO problem_course (id, problem_id, course_id)
+VALUES (1, 1, 1);
+INSERT INTO problem_course (id, problem_id, course_id)
+VALUES (2, 2, 2);

--- a/src/test/resources/integration-test-data.sql
+++ b/src/test/resources/integration-test-data.sql
@@ -1,0 +1,34 @@
+-- Create and insert data for course table (if applicable)
+INSERT INTO course (id, name)
+VALUES (1, 'FRONTEND');
+INSERT INTO course (id, name)
+VALUES (2, 'BACKEND');
+
+-- Create and insert data for tag table
+INSERT INTO tag (id, name)
+VALUES (1, 'JAVASCRIPT');
+INSERT INTO tag (id, name)
+VALUES (2, 'JAVA');
+
+-- Create and insert data for problem table
+INSERT INTO problem (id, title)
+VALUES (1, '클로저에 대해서 설명해주세요');
+INSERT INTO problem (id, title)
+VALUES (2, '함수형 프로그래밍에 대해서 설명해주세요');
+INSERT INTO problem (id, title)
+VALUES (3, '자바 Enum에 대해서 설명해주세요');
+
+-- Create and insert data for problem_tag table
+INSERT INTO problem_tag (id, problem_id, tag_id)
+VALUES (1, 1, 1); -- problem 1 has JAVASCRIPT tag
+INSERT INTO problem_tag (id, problem_id, tag_id)
+VALUES (2, 2, 1); -- problem 2 has JAVASCRIPT tag
+INSERT INTO problem_tag (id, problem_id, tag_id)
+VALUES (3, 3, 2); -- problem 3 has JAVA tag
+
+INSERT INTO problem_course (id, problem_id, course_id)
+VALUES (1, 1, 1);
+INSERT INTO problem_course (id, problem_id, course_id)
+VALUES (2, 2, 1);
+INSERT INTO problem_course (id, problem_id, course_id)
+VALUES (3, 3, 2);

--- a/src/test/resources/tag-test-data.sql
+++ b/src/test/resources/tag-test-data.sql
@@ -1,0 +1,11 @@
+-- Create and insert data for tag table
+INSERT INTO tag (id, name)
+VALUES (1, 'JAVA');
+INSERT INTO tag (id, name)
+VALUES (2, 'JAVASCRIPT');
+
+-- Create and insert data for problem_tag table
+INSERT INTO problem_tag (id, problem_id, tag_id)
+VALUES (1, 1, 1);
+INSERT INTO problem_tag (id, problem_id, tag_id)
+VALUES (2, 1, 2);


### PR DESCRIPTION
- [x] 문제, 태그, 코스 상호 의존성 제거 
- [x] 문제, 태그, 코스 DB 조회 기능 
- [x] 문제와 태그, 코스관련 된 모든 정보를 포함하는 도메인 ProblemWithMetadata 정의
- [x] 문제 목록 조회 API 구현
  - [x] 필터링 기능 추가

### 참고사항 
- 필터링은 코스, 태그로 할 수 있음
- 코스는 단스, 태그는 복수로 필터링 가능