### PR TITLE
[CUS-16] 글로벌 예외 처리 공통화 

### DIFF
--- a/src/main/java/com/continuous/backend/domain/Course.java
+++ b/src/main/java/com/continuous/backend/domain/Course.java
@@ -2,6 +2,9 @@ package com.continuous.backend.domain;
 
 import java.util.Arrays;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 public enum Course {
     BACKEND, FRONTEND;
 
@@ -9,6 +12,6 @@ public enum Course {
         return Arrays.stream(values())
             .filter(course -> course.name().equals(value))
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않는 코스 값 입니다: " + value));
+            .orElseThrow(() -> new CoreException(CoreErrorType.RESOURCE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/continuous/backend/domain/Problem.java
+++ b/src/main/java/com/continuous/backend/domain/Problem.java
@@ -2,6 +2,9 @@ package com.continuous.backend.domain;
 
 import java.util.Objects;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 import lombok.Getter;
 
 @Getter
@@ -18,8 +21,11 @@ public class Problem {
     }
 
     private void validateTitle(String title) {
-        if (title == null || title.isBlank() || title.length() > 50) {
-            throw new IllegalArgumentException("문제의 제목은 비어있거나 50자를 넘을 수 없습니다.");
+        if (title == null || title.isBlank()) {
+            throw new CoreException(CoreErrorType.PROBLEM_TITLE_EMPTY);
+        }
+        if (title.length() > 50) {
+            throw new CoreException(CoreErrorType.PROBLEM_TITLE_TOO_LONG);
         }
     }
 

--- a/src/main/java/com/continuous/backend/domain/Solution.java
+++ b/src/main/java/com/continuous/backend/domain/Solution.java
@@ -2,6 +2,9 @@ package com.continuous.backend.domain;
 
 import java.util.Objects;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 import lombok.Getter;
 
 @Getter
@@ -13,7 +16,7 @@ public class Solution {
 
     public Solution(Long id, String content, long problemId) {
         validateContent(content);
-        
+
         this.id = id;
         this.content = content;
         this.problemId = problemId;
@@ -24,8 +27,11 @@ public class Solution {
     }
 
     private void validateContent(String content) {
-        if (content == null || content.isBlank() || content.length() > 100) {
-            throw new IllegalArgumentException("답변은 비어있거나 100자를 넘을 수 없습니다.");
+        if (content == null || content.isBlank()) {
+            throw new CoreException(CoreErrorType.SOLUTION_CONTENT_EMPTY);
+        }
+        if (content.length() > 100) {
+            throw new CoreException(CoreErrorType.SOLUTION_CONTENT_TOO_LONG);
         }
     }
 

--- a/src/main/java/com/continuous/backend/domain/SolutionService.java
+++ b/src/main/java/com/continuous/backend/domain/SolutionService.java
@@ -2,6 +2,9 @@ package com.continuous.backend.domain;
 
 import org.springframework.stereotype.Service;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 @Service
 public class SolutionService {
 
@@ -16,7 +19,7 @@ public class SolutionService {
     public Solution submit(String content, long problemId) {
         boolean exists = problemRepository.existsById(problemId);
         if (!exists) {
-            throw new IllegalArgumentException("ID에 해당하는 문제가 없습니다. problemId: " + problemId);
+            throw new CoreException(CoreErrorType.RESOURCE_NOT_FOUND);
         }
         return solutionRepository.save(new Solution(content, problemId));
     }

--- a/src/main/java/com/continuous/backend/domain/Tag.java
+++ b/src/main/java/com/continuous/backend/domain/Tag.java
@@ -2,6 +2,9 @@ package com.continuous.backend.domain;
 
 import java.util.Arrays;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 public enum Tag {
     JAVA, JAVASCRIPT;
 
@@ -9,6 +12,6 @@ public enum Tag {
         return Arrays.stream(values())
             .filter(tag -> tag.name().equals(value))
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 태그 값입니다: " + value));
+            .orElseThrow(() -> new CoreException(CoreErrorType.RESOURCE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/continuous/backend/exception/CoreErrorType.java
+++ b/src/main/java/com/continuous/backend/exception/CoreErrorType.java
@@ -16,6 +16,10 @@ public enum CoreErrorType {
     BAD_REQUEST("BAD_REQUEST", "요청이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     TOO_MANY_REQUESTS("TOO_MANY_REQUESTS", "너무 많은 요청이 발생했습니다.", HttpStatus.TOO_MANY_REQUESTS),
 
+    // Problem
+    PROBLEM_TITLE_EMPTY("PROBLEM_TITLE_EMTPY", "문제의 제목은 비어있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    PROBLEM_TITLE_TOO_LONG("PROBLEM_TITLE_TOO_LONG", "문제의 제목은 50자를 넘을 수 없습니다.", HttpStatus.BAD_REQUEST),
+
     // Solution
     SOLUTION_CONTENT_EMPTY("SOLUTION_CONTENT_EMPTY", "답변은 비어있을 수 없습니다.", HttpStatus.BAD_REQUEST),
     SOLUTION_CONTENT_TOO_LONG("SOLUTION_CONTENT_TOO_LONG", "답변은 100자를 넘을 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/continuous/backend/exception/CoreErrorType.java
+++ b/src/main/java/com/continuous/backend/exception/CoreErrorType.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum CoreErrorType {
 
+    // 공통
     RESOURCE_NOT_FOUND("RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_INPUT("INVALID_INPUT", "제공된 입력이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED("UNAUTHORIZED", "사용자가 인증되지 않았습니다.", HttpStatus.UNAUTHORIZED),
@@ -13,7 +14,11 @@ public enum CoreErrorType {
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "예상치 못한 서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE", "현재 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     BAD_REQUEST("BAD_REQUEST", "요청이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-    TOO_MANY_REQUESTS("TOO_MANY_REQUESTS", "너무 많은 요청이 발생했습니다.", HttpStatus.TOO_MANY_REQUESTS);
+    TOO_MANY_REQUESTS("TOO_MANY_REQUESTS", "너무 많은 요청이 발생했습니다.", HttpStatus.TOO_MANY_REQUESTS),
+
+    // Solution
+    SOLUTION_CONTENT_EMPTY("SOLUTION_CONTENT_EMPTY", "답변은 비어있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    SOLUTION_CONTENT_TOO_LONG("SOLUTION_CONTENT_TOO_LONG", "답변은 100자를 넘을 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/continuous/backend/exception/CoreErrorType.java
+++ b/src/main/java/com/continuous/backend/exception/CoreErrorType.java
@@ -1,0 +1,39 @@
+package com.continuous.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum CoreErrorType {
+
+    RESOURCE_NOT_FOUND("RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_INPUT("INVALID_INPUT", "제공된 입력이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("UNAUTHORIZED", "사용자가 인증되지 않았습니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("FORBIDDEN", "이 리소스에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    CONFLICT("CONFLICT", "리소스의 현재 상태와 충돌이 발생했습니다.", HttpStatus.CONFLICT),
+    DATA_INTEGRITY_VIOLATION("DATA_INTEGRITY_VIOLATION", "데이터 무결성 위반이 발생했습니다.", HttpStatus.BAD_REQUEST),
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "예상치 못한 서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SERVICE_UNAVAILABLE("SERVICE_UNAVAILABLE", "현재 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    BAD_REQUEST("BAD_REQUEST", "요청이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    TOO_MANY_REQUESTS("TOO_MANY_REQUESTS", "너무 많은 요청이 발생했습니다.", HttpStatus.TOO_MANY_REQUESTS);
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+
+    CoreErrorType(String errorCode, String message, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/continuous/backend/exception/CoreException.java
+++ b/src/main/java/com/continuous/backend/exception/CoreException.java
@@ -2,11 +2,11 @@ package com.continuous.backend.exception;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class CoreException extends RuntimeException {
+public class CoreException extends RuntimeException {
 
     private final CoreErrorType errorType;
 
-    protected CoreException(CoreErrorType errorType) {
+    public CoreException(CoreErrorType errorType) {
         super(errorType.getMessage());
         this.errorType = errorType;
     }

--- a/src/main/java/com/continuous/backend/exception/CoreException.java
+++ b/src/main/java/com/continuous/backend/exception/CoreException.java
@@ -1,0 +1,25 @@
+package com.continuous.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class CoreException extends RuntimeException {
+
+    private final CoreErrorType errorType;
+
+    protected CoreException(CoreErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+    public String getErrorCode() {
+        return errorType.getErrorCode();
+    }
+
+    public String getMessage() {
+        return errorType.getMessage();
+    }
+
+    public HttpStatus getStatus() {
+        return errorType.getStatus();
+    }
+}

--- a/src/main/java/com/continuous/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/continuous/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.continuous.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.continuous.backend.support.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CoreException.class)
+    public ResponseEntity<ApiResponse<String>> handleResourceNotFoundException(CoreException ex) {
+        ApiResponse<String> response = ApiResponse.error(ex.getMessage(), ex.getErrorCode());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleGeneralException(Exception ex) {
+        ApiResponse<String> response = ApiResponse.error(CoreErrorType.INTERNAL_SERVER_ERROR.getMessage(), CoreErrorType.INTERNAL_SERVER_ERROR.getErrorCode());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/com/continuous/backend/infrastructure/CourseCoreRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/CourseCoreRepository.java
@@ -1,11 +1,11 @@
 package com.continuous.backend.infrastructure;
 
-import java.util.NoSuchElementException;
-
 import org.springframework.stereotype.Repository;
 
 import com.continuous.backend.domain.Course;
 import com.continuous.backend.domain.CourseRepository;
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
 
 @Repository
 public class CourseCoreRepository implements CourseRepository {
@@ -19,7 +19,7 @@ public class CourseCoreRepository implements CourseRepository {
     @Override
     public Course findByProblemId(long problemId) {
         CourseEntity courseEntity = CourseJpaRepository.findByProblemId(problemId)
-            .orElseThrow(() -> new NoSuchElementException("해당 problemId 에 해당하는 코스가 존재하지 않습니다. problemId: " + problemId));
+            .orElseThrow(() -> new CoreException(CoreErrorType.RESOURCE_NOT_FOUND));
         return courseEntity.toCourse();
     }
 }

--- a/src/main/java/com/continuous/backend/infrastructure/ProblemCoreRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/ProblemCoreRepository.java
@@ -1,12 +1,13 @@
 package com.continuous.backend.infrastructure;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Repository;
 
 import com.continuous.backend.domain.Problem;
 import com.continuous.backend.domain.ProblemRepository;
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
 
 @Repository
 public class ProblemCoreRepository implements ProblemRepository {
@@ -27,7 +28,7 @@ public class ProblemCoreRepository implements ProblemRepository {
     @Override
     public Problem findById(long problemId) {
         ProblemEntity problemEntity = problemJpaRepository.findById(problemId)
-            .orElseThrow(() -> new NoSuchElementException("ID에 해당하는 문제가 없습니다. ID: " + problemId));
+            .orElseThrow(() -> new CoreException(CoreErrorType.RESOURCE_NOT_FOUND));
 
         return problemEntity.toProblem();
     }

--- a/src/main/java/com/continuous/backend/support/ApiResponse.java
+++ b/src/main/java/com/continuous/backend/support/ApiResponse.java
@@ -1,12 +1,12 @@
 package com.continuous.backend.support;
 
-public record ApiResponse<T>(String status, String message, T data) {
+public record ApiResponse<T>(String status, String message, T data, String errorCode) {
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>("success", null, data);
+        return new ApiResponse<>("success", null, data, null);
     }
 
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>("error", message, null);
+    public static <T> ApiResponse<T> error(String message, String errorCode) {
+        return new ApiResponse<>("error", message, null, errorCode);
     }
 }

--- a/src/test/java/com/continuous/backend/domain/CourseTest.java
+++ b/src/test/java/com/continuous/backend/domain/CourseTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.continuous.backend.exception.CoreException;
+
 public class CourseTest {
 
     @DisplayName("유효한 코스 값을 변환할 수 있다.")
@@ -26,6 +28,6 @@ public class CourseTest {
     void from_invalidValue_throwsException() {
         // when & then
         assertThatThrownBy(() -> Course.from("INVALID"))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(CoreException.class);
     }
 }

--- a/src/test/java/com/continuous/backend/domain/ProblemTest.java
+++ b/src/test/java/com/continuous/backend/domain/ProblemTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 class ProblemTest {
 
     @DisplayName("문제의 제목은 비어있을 수 없다.")
@@ -15,8 +18,8 @@ class ProblemTest {
     void create_emptyTitle(String title) {
         // when & then
         assertThatThrownBy(() -> new Problem(1L, title))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("문제의 제목은 비어있거나 50자를 넘을 수 없습니다.");
+            .isInstanceOf(CoreException.class)
+            .hasMessage(CoreErrorType.PROBLEM_TITLE_EMPTY.getMessage());
     }
 
     @DisplayName("문제의 제목은 50글자를 넘을 수 없다.")
@@ -27,7 +30,7 @@ class ProblemTest {
 
         // when & then
         assertThatThrownBy(() -> new Problem(1L, title))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("문제의 제목은 비어있거나 50자를 넘을 수 없습니다.");
+            .isInstanceOf(CoreException.class)
+            .hasMessage(CoreErrorType.PROBLEM_TITLE_TOO_LONG.getMessage());
     }
 }

--- a/src/test/java/com/continuous/backend/domain/SolutionServiceTest.java
+++ b/src/test/java/com/continuous/backend/domain/SolutionServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
 import com.continuous.backend.support.MockProblemRepository;
 import com.continuous.backend.support.MockSolutionRepository;
 
@@ -44,6 +46,7 @@ class SolutionServiceTest {
 
         // when & then
         assertThatThrownBy(() -> solutionService.submit(content, problemId))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(CoreException.class)
+            .hasMessage(CoreErrorType.RESOURCE_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/continuous/backend/domain/SolutionTest.java
+++ b/src/test/java/com/continuous/backend/domain/SolutionTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
+
 class SolutionTest {
 
     @DisplayName("답변의 길이는 100자 이하여야 한다.")
@@ -15,8 +18,8 @@ class SolutionTest {
     void create_blank(String content) {
         // when & then
         assertThatThrownBy(() -> new Solution(content, 1L))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("답변은 비어있거나 100자를 넘을 수 없습니다.");
+            .isInstanceOf(CoreException.class)
+            .hasMessage(CoreErrorType.SOLUTION_CONTENT_EMPTY.getMessage());
     }
 
     @DisplayName("답변의 길이는 100자 이하여야 한다.")
@@ -27,7 +30,7 @@ class SolutionTest {
 
         // when & then
         assertThatThrownBy(() -> new Solution(content, 1L))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("답변은 비어있거나 100자를 넘을 수 없습니다.");
+            .isInstanceOf(CoreException.class)
+            .hasMessage(CoreErrorType.SOLUTION_CONTENT_TOO_LONG.getMessage());
     }
 }

--- a/src/test/java/com/continuous/backend/domain/TagTest.java
+++ b/src/test/java/com/continuous/backend/domain/TagTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.continuous.backend.exception.CoreException;
+
 class TagTest {
 
     @DisplayName("유효한 태그 값을 변환할 수 있다.")
@@ -26,6 +28,6 @@ class TagTest {
     void from_invalidValue_throwsException(String value) {
         // when & then
         assertThatThrownBy(() -> Tag.from(value))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(CoreException.class);
     }
 }

--- a/src/test/java/com/continuous/backend/infrastructure/ProblemCoreRepositoryTest.java
+++ b/src/test/java/com/continuous/backend/infrastructure/ProblemCoreRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +15,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.continuous.backend.domain.Problem;
+import com.continuous.backend.exception.CoreErrorType;
+import com.continuous.backend.exception.CoreException;
 
 @DataJpaTest
 @Import(ProblemCoreRepository.class)
@@ -70,7 +71,8 @@ class ProblemCoreRepositoryTest {
 
         // when & then
         assertThatThrownBy(() -> problemCoreRepository.findById(problemId))
-            .isInstanceOf(NoSuchElementException.class);
+            .isInstanceOf(CoreException.class)
+            .hasMessage(CoreErrorType.RESOURCE_NOT_FOUND.getMessage());
     }
 }
 

--- a/src/test/java/com/continuous/backend/presentation/ProblemControllerIntegrationTest.java
+++ b/src/test/java/com/continuous/backend/presentation/ProblemControllerIntegrationTest.java
@@ -158,7 +158,7 @@ class ProblemControllerIntegrationTest {
             .when()
             .get("/v1/problems/{id}")
             .then()
-            .statusCode(500) // TODO: 에러 공통화
+            .statusCode(404)
             .contentType(ContentType.JSON);
         // .body("status", equalTo("error"));
         // .body("message", notNullValue());

--- a/src/test/java/com/continuous/backend/presentation/SolutionControllerIntegrationTest.java
+++ b/src/test/java/com/continuous/backend/presentation/SolutionControllerIntegrationTest.java
@@ -81,7 +81,7 @@ class SolutionControllerIntegrationTest {
             .when()
             .post("/v1/problems/{id}/solutions", problemId)
             .then()
-            .statusCode(500) // TODO: 에러 공통화
+            .statusCode(404)
             .contentType(ContentType.JSON);
     }
 }


### PR DESCRIPTION
### CoreException
```java
public class CoreException extends RuntimeException {

    private final CoreErrorType errorType;

    public CoreException(CoreErrorType errorType) {
        super(errorType.getMessage());
        this.errorType = errorType;
    }
    // ...
```
공통되고 일관성있는 예외 처리 전략을 위해 에러와 관련된 정보를 가지는 CoreErrorType 을 정의합니다. 

```java
@Override
public Problem findById(long problemId) {
    ProblemEntity problemEntity = problemJpaRepository.findById(problemId)
        .orElseThrow(() -> new CoreException(CoreErrorType.RESOURCE_NOT_FOUND));

    return problemEntity.toProblem();
}
```
사용시에는 위 처럼 CoreErrorType의 적절한 예외 케이스를 선택합니다. 적절한 케이스가 없을 시 추가할 수 있습니다. 

### CoreErrorType
```java
public enum CoreErrorType {

    // 공통
    RESOURCE_NOT_FOUND("RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
    INVALID_INPUT("INVALID_INPUT", "제공된 입력이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
    UNAUTHORIZED("UNAUTHORIZED", "사용자가 인증되지 않았습니다.", HttpStatus.UNAUTHORIZED),

    // ... 
```
에러타입은 errorCode, message, HttpStatus 의 조합으로 고유한 케이스가 만들어집니다.
가독성을 위해 공통, 도메인 별 케이스를 주석으로 구분하여 작성합니다. 