### PR TITLE
[CUS-17] 답변 목록 가져오기 API 구현

### DIFF
--- a/src/main/java/com/continuous/backend/domain/SolutionRepository.java
+++ b/src/main/java/com/continuous/backend/domain/SolutionRepository.java
@@ -1,6 +1,10 @@
 package com.continuous.backend.domain;
 
+import java.util.List;
+
 public interface SolutionRepository {
 
     Solution save(Solution solution);
+
+    List<Solution> findAllByProblemId(long problemId);
 }

--- a/src/main/java/com/continuous/backend/domain/SolutionService.java
+++ b/src/main/java/com/continuous/backend/domain/SolutionService.java
@@ -1,5 +1,7 @@
 package com.continuous.backend.domain;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.continuous.backend.exception.CoreErrorType;
@@ -17,10 +19,19 @@ public class SolutionService {
     }
 
     public Solution submit(String content, long problemId) {
+        validateProblemExists(problemId);
+        return solutionRepository.save(new Solution(content, problemId));
+    }
+
+    public List<Solution> getSolutions(long problemId) {
+        validateProblemExists(problemId);
+        return solutionRepository.findAllByProblemId(problemId);
+    }
+
+    private void validateProblemExists(long problemId) {
         boolean exists = problemRepository.existsById(problemId);
         if (!exists) {
             throw new CoreException(CoreErrorType.RESOURCE_NOT_FOUND);
         }
-        return solutionRepository.save(new Solution(content, problemId));
     }
 }

--- a/src/main/java/com/continuous/backend/infrastructure/SolutionCoreRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/SolutionCoreRepository.java
@@ -1,5 +1,7 @@
 package com.continuous.backend.infrastructure;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import com.continuous.backend.domain.Solution;
@@ -18,5 +20,12 @@ public class SolutionCoreRepository implements SolutionRepository {
     public Solution save(Solution solution) {
         SolutionEntity solutionEntity = solutionJpaRepository.save(SolutionEntity.from(solution));
         return solutionEntity.toSolution();
+    }
+
+    @Override
+    public List<Solution> findAllByProblemId(long problemId) {
+        return solutionJpaRepository.findAllByProblemId(problemId).stream()
+            .map(SolutionEntity::toSolution)
+            .toList();
     }
 }

--- a/src/main/java/com/continuous/backend/infrastructure/SolutionJpaRepository.java
+++ b/src/main/java/com/continuous/backend/infrastructure/SolutionJpaRepository.java
@@ -1,6 +1,10 @@
 package com.continuous.backend.infrastructure;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SolutionJpaRepository extends JpaRepository<SolutionEntity, Long> {
+
+    List<SolutionEntity> findAllByProblemId(long problemId);
 }

--- a/src/main/java/com/continuous/backend/presentation/SolutionController.java
+++ b/src/main/java/com/continuous/backend/presentation/SolutionController.java
@@ -1,5 +1,8 @@
 package com.continuous.backend.presentation;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,5 +30,13 @@ public class SolutionController {
         Solution solution = solutionService.submit(request.content(), problemId);
 
         return ApiResponse.success(SolutionResponse.from(solution));
+    }
+
+    @GetMapping("/{id}/solutions")
+    public ApiResponse<List<SolutionResponse>> getSolutions(@PathVariable("id") long problemId) {
+        List<Solution> solutions = solutionService.getSolutions(problemId);
+        List<SolutionResponse> responses = solutions.stream().map(SolutionResponse::from).toList();
+
+        return ApiResponse.success(responses);
     }
 }

--- a/src/test/java/com/continuous/backend/domain/SolutionServiceTest.java
+++ b/src/test/java/com/continuous/backend/domain/SolutionServiceTest.java
@@ -2,6 +2,8 @@ package com.continuous.backend.domain;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,5 +50,24 @@ class SolutionServiceTest {
         assertThatThrownBy(() -> solutionService.submit(content, problemId))
             .isInstanceOf(CoreException.class)
             .hasMessage(CoreErrorType.RESOURCE_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("문제의 모든 솔루션을 조회한다.")
+    @Test
+    void getSolutions() {
+        // given
+        long problemId = 1L;
+        String content1 = "나의 답변 1";
+        solutionService.submit(content1, problemId);
+        String content2 = "나의 답변 2";
+        solutionService.submit(content2, problemId);
+
+        // when
+        List<Solution> solutions = solutionService.getSolutions(problemId);
+
+        //then
+        assertThat(solutions).hasSize(2);
+        assertThat(solutions.get(0).getContent()).isEqualTo(content1);
+        assertThat(solutions.get(1).getContent()).isEqualTo(content2);
     }
 }

--- a/src/test/java/com/continuous/backend/infrastructure/SolutionCoreRepositoryTest.java
+++ b/src/test/java/com/continuous/backend/infrastructure/SolutionCoreRepositoryTest.java
@@ -2,11 +2,14 @@ package com.continuous.backend.infrastructure;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
 
 import com.continuous.backend.domain.Solution;
 
@@ -28,5 +31,19 @@ class SolutionCoreRepositoryTest {
 
         // then
         assertThat(savedSolution.getContent()).isEqualTo("나의 답변");
+    }
+
+    @DisplayName("문제의 전체 답변을 조회한다.")
+    @Test
+    @Sql("/solution-test-data.sql")
+    void findAll() {
+        // given
+        long problemId = 1L;
+
+        // when
+        List<Solution> solutions = solutionCoreRepository.findAllByProblemId(problemId);
+
+        //then
+        assertThat(solutions).hasSize(2);
     }
 }

--- a/src/test/java/com/continuous/backend/presentation/SolutionControllerIntegrationTest.java
+++ b/src/test/java/com/continuous/backend/presentation/SolutionControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -80,6 +81,40 @@ class SolutionControllerIntegrationTest {
             .body(requestBody)
             .when()
             .post("/v1/problems/{id}/solutions", problemId)
+            .then()
+            .statusCode(404)
+            .contentType(ContentType.JSON);
+    }
+
+    @DisplayName("GET /v1/problems/{id}/solutions - 문제에 대한 솔루션 목록을 조회한다.")
+    @Test
+    @Sql("/solution-test-data.sql")
+    void getSolutions() {
+        long problemId = 1L;
+
+        given()
+            .contentType(ContentType.JSON)
+            .when()
+            .get("/v1/problems/{id}/solutions", problemId)
+            .then()
+            .statusCode(200)
+            .contentType(ContentType.JSON)
+            .body("status", equalTo("success"))
+            .body("data", not(empty()))
+            .body("data.size()", greaterThan(0))
+            .body("data[0].problemId", equalTo((int)problemId))
+            .body("data[0].content", notNullValue());
+    }
+
+    @DisplayName("GET /v1/problems/{id}/solutions - 존재하지 않는 문제 ID로 조회하면 404를 반환한다.")
+    @Test
+    void getSolutionsByNonExistentProblemId() {
+        long problemId = 9999L;
+
+        given()
+            .contentType(ContentType.JSON)
+            .when()
+            .get("/v1/problems/{id}/solutions", problemId)
             .then()
             .statusCode(404)
             .contentType(ContentType.JSON);

--- a/src/test/java/com/continuous/backend/support/MockSolutionRepository.java
+++ b/src/test/java/com/continuous/backend/support/MockSolutionRepository.java
@@ -1,6 +1,8 @@
 package com.continuous.backend.support;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -21,5 +23,16 @@ public class MockSolutionRepository implements SolutionRepository {
         }
         storage.replace(solution.getId(), solution);
         return solution;
+    }
+
+    @Override
+    public List<Solution> findAllByProblemId(long problemId) {
+        ArrayList<Solution> solutions = new ArrayList<>();
+        for (Solution solution : storage.values()) {
+            if (solution.getProblemId() == problemId) {
+                solutions.add(solution);
+            }
+        }
+        return solutions;
     }
 }

--- a/src/test/resources/solution-test-data.sql
+++ b/src/test/resources/solution-test-data.sql
@@ -1,0 +1,4 @@
+INSERT INTO solution (id, content, problem_id)
+VALUES (1, '답변 1', 1);
+INSERT INTO solution (id, content, problem_id)
+VALUES (2, '답변 2', 1);

--- a/src/test/resources/solution-test-data.sql
+++ b/src/test/resources/solution-test-data.sql
@@ -1,3 +1,5 @@
+TRUNCATE TABLE solution;
+
 INSERT INTO solution (id, content, problem_id)
 VALUES (1, '답변 1', 1);
 INSERT INTO solution (id, content, problem_id)


### PR DESCRIPTION
# 답변 목록 가져오기

카테고리: problem
메서드: GET
URL: /v1/problems/{id}/solutions

## Request

### Path Parameter

| 파라미터 | 타입 | **필수 여부** | **설명** |
| --- | --- | --- | --- |
| id | `Long` | `true` | 조회할 문제 ID. |

## Response

### Body

| 필드 | 타입 | 설명 |
| --- | --- | --- |
| id | `Long`  | 답변 ID |
| content | `String` | 답변 내용 |
- **상태 코드 200 OK**: 지정된 문제 ID에 대한 풀이 목록을 반환합니다.
    
    ```json
    [
      {
        "id": 1,
        "content": "const exampleSolution = (input) => input * 2;",
      },
      {
        "id": 2,
        "content": "public int exampleSolution(int input) { return input * 2; }",
      }
    ]
    ```
    
- **상태 코드 404 Not Found**: 지정된 문제 ID에 대한 풀이가 없는 경우.